### PR TITLE
Add relate_n DSL and function to make DSLs on the fly

### DIFF
--- a/ecLearner.py
+++ b/ecLearner.py
@@ -30,7 +30,7 @@ from dreamcoder.task import *
 from pyccg.lexicon import Lexicon
 from pyccg.word_learner import WordLearner
 
-from puddleworldOntology import ontology, ec_ontology, process_scene, puddleworld_ec_translation_fn
+from puddleworldOntology import make_puddleworld_ontology, process_scene, puddleworld_ec_translation_fn
 from puddleworldTasks import *
 from utils import convertOntology, ecTaskAsPyCCGUpdate, filter_tasks_mlu, MLUTaskBatcher
 
@@ -114,7 +114,7 @@ initial_puddleworld_lex = Lexicon.fromstring(r"""
   # heart => N {unique(\x.heart(x))}
   # circle => N {\x.circle(x)}
   # triangle => N {\x.triangle(x)}
-""", ontology, include_semantics=True)
+""", make_puddleworld_ontology(ontology_type='pyccg'), include_semantics=True)
 
 class ECLanguageLearner:
     """
@@ -304,6 +304,12 @@ def puddleworld_options(parser):
 
     # Puddleworld-specific.
     parser.add_argument(
+        "--ontology",
+        default='default',
+        help='Which ontology: [default, relate_n]',
+        type=str,
+        )
+    parser.add_argument(
         "--use_initial_lexicon",
         action="store_true",
         help='Initialize PyCCG learner with a predefined initial lexicon.'
@@ -370,7 +376,11 @@ if __name__ == "__main__":
         os.system("mkdir -p %s"%outputDirectory)
 
         # Convert pyccg ontology -> Dreamcoder.
-        puddleworldTypes, puddleworldPrimitives = convertOntology(ec_ontology)
+
+        ontology_type = args.pop('ontology')
+        puddleworldOntology = make_puddleworld_ontology(ontology_type)
+
+        puddleworldTypes, puddleworldPrimitives = convertOntology(puddleworldOntology)
         input_type, output_type = puddleworldTypes['model'], puddleworldTypes['action']
 
         # Convert sentences-scenes -> Dreamcoder style tasks.

--- a/learner.py
+++ b/learner.py
@@ -10,8 +10,10 @@ import numpy as np
 from tqdm import tqdm
 
 #### Add EC dependency
-sys.path.append("../ec")
-sys.path.append("../pyccg")
+sys.path.insert(0, "../")
+sys.path.insert(0, "../ec/")
+sys.path.insert(0, "../pyccg")
+sys.path.insert(0, "../pyccg/nltk")
 from puddleworldTasks import loadPuddleWorldTasks
 
 from pyccg.chart import WeightedCCGChartParser, printCCGDerivation
@@ -20,7 +22,7 @@ from pyccg.lexicon import Lexicon
 from pyccg.logic import TypeSystem, Ontology, Expression
 from pyccg.word_learner import WordLearner
 
-from puddleworldOntology import ontology, process_scene
+from puddleworldOntology import make_puddleworld_ontology, process_scene
 
 
 #########
@@ -36,7 +38,7 @@ sorted_idxs = lengths.argsort()
 #######
 # Lexicon: defines an initial set of word -> (syntax, meaning) mappings.
 # Weights are initialized uniformly by default.
-
+ontology = make_puddleworld_ontology(ontology_type='pyccg')
 
 initial_lex = Lexicon.fromstring(r"""
   :- S:N

--- a/puddleworldTasks.py
+++ b/puddleworldTasks.py
@@ -3,9 +3,9 @@
 import numpy as np
 import string
 
-from task import *
+from dreamcoder.task import *
 
-from puddleworldOntology import ec_ontology, process_scene
+from puddleworldOntology import make_puddleworld_ontology, process_scene
 
 #### Utility functions to load and prepare dataset for EC.
 def loadPuddleWorldTasks(datafile='data/puddleworld.json'):

--- a/test/test_puddleworldOntology.py
+++ b/test/test_puddleworldOntology.py
@@ -19,10 +19,11 @@ from dreamcoder.ec import Task
 from dreamcoder.type import arrow
 import dreamcoder.program as ec_program
 
-from puddleworldOntology import ontology, ec_ontology, process_scene
+from puddleworldOntology import make_puddleworld_ontology, process_scene
 from utils import ecTaskAsPyCCGUpdate, convertOntology
 
-
+ontology = make_puddleworld_ontology('pyccg')
+ec_ontology = make_puddleworld_ontology('default')
 
 SIMPLE_SCENE = np.array(
     [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 8.0, 2.0],


### PR DESCRIPTION
Function to create ontologies rather than importing ones with slightly different names.

Adds an experimental ontology with the vanilla 'relate' function removed and just 'relate_n' to encourage learning how to use the more general relate function.